### PR TITLE
Changed dateutil.parser.parse to dateutil.parser.isoparse

### DIFF
--- a/build/PureCloudPlatformClientV2/api_client.py
+++ b/build/PureCloudPlatformClientV2/api_client.py
@@ -726,8 +726,8 @@ class ApiClient(object):
         :return: date.
         """
         try:
-            from dateutil.parser import parse
-            return parse(string).date()
+            from dateutil.parser import isoparse
+            return isoparse(string).date()
         except ImportError:
             return string
         except ValueError:
@@ -747,8 +747,8 @@ class ApiClient(object):
         :return: datetime.
         """
         try:
-            from dateutil.parser import parse
-            return parse(string)
+            from dateutil.parser import isoparse
+            return isoparse(string)
         except ImportError:
             return string
         except ValueError:


### PR DESCRIPTION
I have found that changing dateutil.parser.parse to dateutil.parser.isoparse has significantly decreased the deserialization time when running a get_analytics_conversations_details_job_results() query. I can imagine it would improve all queries to some degree. The downside is that I am not sure if it's guaranteed that the input date time string is ISO-8601 formatted.

It would require dateutil version >= 2.7.0
https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse